### PR TITLE
Fix SD file corruption

### DIFF
--- a/processing_scripts/calibrateOOBS.m
+++ b/processing_scripts/calibrateOOBS.m
@@ -61,7 +61,6 @@ for j = 1:numel(burstIDs)
 end
 
 % clearvars -except sn data file
-
 close all
 
 figure
@@ -69,8 +68,8 @@ colormap flag
 set(gcf,'Units','normalized')
 set(gcf,'Position',[0.1 0.1 0.8 0.6])
 hold on
-% scatter(data.timeInterp,data.R0_V,10,data.gain,'filled')
-plot(time,measured,'b.','markersize',10);
+scatter(data.timeInterp,data.R0_V,10,data.gain,'filled')
+% plot(time,measured,'b.','markersize',10);
 title(sprintf("Serial no. %03d", sn))
 zoom on
 
@@ -85,12 +84,12 @@ close all
 
 gen_path = "/Users/Ted/GDrive/OpenOBS/Calibrations/";
 
-standards = [0,20,100,500,1000];
+standards = [0,100,500,1000];
 measured = [mean(a(:,2)), std(a(:,2)); 
         mean(b(:,2)), std(b(:,2)); 
         mean(c(:,2)), std(c(:,2)); 
-        mean(d(:,2)), std(d(:,2)); 
-        mean(e(:,2)), std(e(:,2))];
+        mean(d(:,2)), std(d(:,2))]; 
+%         mean(e(:,2)), std(e(:,2))];
 
 lm = fitlm(measured(:,1),standards);
 NTU = predict(lm,measured(:,1));
@@ -108,9 +107,10 @@ end
 save(fullfile(save_path,file(1:8)),"measured","standards","NTU","lm","data")
 
 %% look at a bunch of cal data
-cal_path = dir(fullfile(gen_path,"*","03072021.mat"));
+date_string = "23092021";
+sn_ignore = [];
 
-sn_ignore = [10,15];
+cal_path = dir(fullfile(gen_path,"*",date_string+".mat"));
 lgd_names = {};
 
 close all
@@ -165,6 +165,8 @@ plot(xlim,[0,0],'k--','Linewidth',1)
 
 set(gcf,'Units','normalized')
 set(gcf,'Position',[0.3 0.4 0.4 0.3]);
+
+saveas(gcf,fullfile(gen_path,"calibration_"+date_string+".png"))
 
 
 % lims = get(gca,'XLim') + [-50,50];

--- a/processing_scripts/parseOOBS.m
+++ b/processing_scripts/parseOOBS.m
@@ -4,7 +4,6 @@ clc
 calPath = "/Users/Ted/GDrive/OpenOBS/Calibrations/";
 [file,path] = uigetfile('/*.TXT','Multiselect','on');
 
-%%
 
 %assemble cell array of the selected file paths
 if isa(file,'cell')
@@ -61,14 +60,20 @@ for i = 1:numel(sn)
         %split background and sample measurements
         idxBackground = idx(tmp.gain(idx)==0);
         idxSample = idx(tmp.gain(idx)~=0);
-        background = mean(tmp.R0_V(idxBackground));
+        background = median(tmp.R0_V(idxBackground));
         
-        %average the sampling burst and subtract background
+        %average the sampling burst and filter high background meas.
         resampled.time(j,1) = mean(tmp.dt(idxSample));
         resampled.background(j,1) = background;
-        resampled.R0_V(j,1) = mean(tmp.R0_V(idxSample))-background; 
-        resampled.R0_V_sd(j,1) = std(tmp.R0_V(idxSample));
         resampled.temp(j,1) = tmp.temp(measIdx(j));
+        
+        if background>0.1
+            resampled.R0_V(j,1) = NaN;
+            resampled.R0_V_sd(j,1) = NaN;
+        else
+            resampled.R0_V(j,1) = median(tmp.R0_V(idxSample))-background; 
+            resampled.R0_V_sd(j,1) = std(tmp.R0_V(idxSample));
+        end
         burstID(idx,1) = j;
     end
     tmp.burstID = burstID;
@@ -89,7 +94,7 @@ for i = 1:numel(sn)
     d{i,1} = tmp;
 end
 
-%% plots
+% plots
 close all
 
 figure

--- a/processing_scripts/parseOOBS.m
+++ b/processing_scripts/parseOOBS.m
@@ -93,7 +93,7 @@ for i = 1:numel(sn)
     %store tmp table in data cell array
     d{i,1} = tmp;
 end
-
+%%
 % plots
 close all
 

--- a/sensor_firmware/sensor_firmware.ino
+++ b/sensor_firmware/sensor_firmware.ino
@@ -241,7 +241,7 @@ void loop() {
   serialSend(messageBuffer);
 
   //illuminated measurements
-  digitalWrite(pIRED, HIGH);
+  digitalWrite(pIRED, HIGH); //turn on the IRED
   for (int i = 0; i < NUM_SAMPLES; i++) {
     readBuffer = ads.readADC_SingleEnded(0);
 
@@ -267,8 +267,10 @@ void loop() {
       serialSend(messageBuffer);
     }
   }
+  digitalWrite(pIRED, LOW); //turn off the IRED
   file.close();
-
+  delay(1000);
+  
   //ensure a 5 second margin for the next alarm before shutting down.
   //if the alarm we set during this wake has already passed, the OBS will never wake up.
   long timeUntilAlarm = nextAlarm.unixtime()-rtc.now().unixtime();


### PR DESCRIPTION
Some micro SD cards would corrupt their daily files while closing them on the first time. Turns out some SD cards take longer to finish the file close, and as the file directory on the card grows, the closing and data shuffling can take longer.